### PR TITLE
Fix Schwab workflow YAML quoting

### DIFF
--- a/.github/workflows/schwab.yml
+++ b/.github/workflows/schwab.yml
@@ -25,7 +25,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install --quiet schwab-py google-api-python-client google-auth google-auth-httplib2
 
-      - name: Account hash + quote -> Sheet (tab: schwab)
+      - name: "Account hash + quote -> Sheet (tab: schwab)"
         env:
           SCHWAB_APP_KEY: ${{ secrets.SCHWAB_APP_KEY }}
           SCHWAB_APP_SECRET: ${{ secrets.SCHWAB_APP_SECRET }}


### PR DESCRIPTION
## Summary
- quote step name in Schwab workflow to handle colon in value

## Testing
- `python -m yamllint .github/workflows/schwab.yml` *(fails: line-length errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a68402f8388320a182a45fb587d797