### PR TITLE
Fix Schwab workflow summary write syntax

### DIFF
--- a/.github/workflows/schwab.yml
+++ b/.github/workflows/schwab.yml
@@ -221,8 +221,11 @@ jobs:
 
           # job summary
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
-            f.write("### Schwab order (SPX only)\n\n```
-"+json.dumps(order, indent=2)+"\n```\n")
+            f.write(
+              "### Schwab order (SPX only)\n\n```"
+              + json.dumps(order, indent=2)
+              + "\n```\n"
+            )
             f.write(f"- account_last4: {acct_last4}\n")
             f.write(f"- quote: SPX = {last}\n")
             f.write(f"- read leocross row: 2\n")
@@ -230,4 +233,3 @@ jobs:
             f.write(f"- order_id: {order_id}\n")
             f.write(f"- http_status: {place_http if place_http is not None else preview_http}\n")
           PY
-


### PR DESCRIPTION
## Summary
- fix Python code in schwab.yml that wrote workflow summary

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 200}}}' .github/workflows/schwab.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a6ac48b0c88320b20a1ef8344c6253