### PR TITLE
Add bypass for Schwab Place time gate

### DIFF
--- a/.github/workflows/schwab.yml
+++ b/.github/workflows/schwab.yml
@@ -21,7 +21,13 @@ jobs:
       - name: Gate to 16:12 ET or 13:12 ET (Mon–Fri) — FAIL if not match
         id: gate
         shell: bash
+        env:
+          BYPASS_TIME_GATE: ${{ vars.BYPASS_TIME_GATE }}
         run: |
+          if [ "${BYPASS_TIME_GATE:-}" = "1" ]; then
+            echo "Bypass enabled → proceeding regardless of time."
+            exit 0
+          fi
           ET_TIME="$(TZ=America/New_York date +%H:%M)"
           ET_DOW="$(TZ=America/New_York date +%u)"
           echo "New York time now: $ET_TIME (DOW=$ET_DOW)"


### PR DESCRIPTION
## Summary
- allow optional time gate bypass via `BYPASS_TIME_GATE`
- document bypass logic in Schwab workflow

## Testing
- `yamllint .github/workflows/schwab.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a818f1038083209e6ce8409740f3e6