### PR TITLE
chore: extend Schwab Place env vars

### DIFF
--- a/.github/workflows/schwab.yml
+++ b/.github/workflows/schwab.yml
@@ -63,5 +63,12 @@ jobs:
           OFFSET_DEBIT: ${{ vars.OFFSET_DEBIT }}
           MIN_CREDIT_START: ${{ vars.MIN_CREDIT_START }}
           MAX_DEBIT_START: ${{ vars.MAX_DEBIT_START }}
+          CANCEL_REMAINING: ${{ vars.CANCEL_REMAINING }}
+          # Percent-of-BP sizing
+          SIZE_MODE: ${{ vars.SIZE_MODE }}
+          CREDIT_ALLOC_PCT: ${{ vars.CREDIT_ALLOC_PCT }}
+          DEBIT_ALLOC_PCT: ${{ vars.DEBIT_ALLOC_PCT }}
+          MAX_QTY: ${{ vars.MAX_QTY }}
+          OPT_BP_OVERRIDE: ${{ vars.OPT_BP_OVERRIDE }}
         run: |
           python scripts/schwab_place_order.py


### PR DESCRIPTION
## Summary
- add cancel_remaining and percent-of-BP sizing env vars to Schwab Place workflow

## Testing
- `yamllint .github/workflows/schwab.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a82298a0a88320b6e49af263ec4bef