### PR TITLE
Adjust bypass guard remainder sizing

### DIFF
--- a/scripts/leocross_orchestrator.py
+++ b/scripts/leocross_orchestrator.py
@@ -360,11 +360,11 @@ def main():
 
     # ---- compute remainder ----
     if BYPASS_GUARD:
-        # ignore existing units; force place BYPASS_QTY (default 1)
+        # ignore existing units; if BYPASS_QTY empty, place full target
         try:
-            rem_qty = int(BYPASS_QTY) if BYPASS_QTY else 1
-        except:
-            rem_qty = 1
+            rem_qty = int(BYPASS_QTY) if BYPASS_QTY else int(target_units)
+        except Exception:
+            rem_qty = int(target_units)
         units_open = 0
         decision = "ALLOW_BYPASS"
         detail = f"BYPASS_GUARD=1 width={width} open_cash={oc:.2f} target={target_units} rem_qty={rem_qty}"


### PR DESCRIPTION
## Summary
- update bypass guard sizing to use the calculated target when no BYPASS_QTY override is provided

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc99f7d5ec8320b9a666a358224f2c