### PR TITLE
Shorten Schwab dump default window and run daily

### DIFF
--- a/.github/workflows/schwab_dump_and_summarize.yml
+++ b/.github/workflows/schwab_dump_and_summarize.yml
@@ -4,16 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       days_back:
-        description: "Days of history to pull (default 60)"
+        description: "Days of history to pull (default 5)"
         required: false
-        default: "60"
+        default: "5"
       acc_reset:
         description: "Reset accumulator this run? (1=yes, 0=no)"
         required: false
         default: "0"
   schedule:
-    # 8:00pm ET (00:00 UTC Tue–Sat)
-    - cron: "0 0 * * 2-6"
+    # 8:00pm ET (00:00 UTC every day)
+    - cron: "0 0 * * *"
 
 concurrency:
   group: schwab-sheets
@@ -42,7 +42,7 @@ jobs:
           SCHWAB_APP_KEY: ${{ secrets.SCHWAB_APP_KEY }}
           SCHWAB_APP_SECRET: ${{ secrets.SCHWAB_APP_SECRET }}
           SCHWAB_TOKEN_JSON: ${{ secrets.SCHWAB_TOKEN_JSON }}
-          DAYS_BACK: ${{ github.event.inputs.days_back != '' && github.event.inputs.days_back || '60' }}
+          DAYS_BACK: ${{ github.event.inputs.days_back != '' && github.event.inputs.days_back || '5' }}
         run: |
           python scripts/schwab_dump_all_txns.py
 

--- a/scripts/schwab_dump_all_txns.py
+++ b/scripts/schwab_dump_all_txns.py
@@ -13,7 +13,7 @@ Schwab → Sheets RAW loader (LEDGER-ONLY, per-fill fees, no duplicates).
 Env:
   GSHEET_ID, GOOGLE_SERVICE_ACCOUNT_JSON
   SCHWAB_APP_KEY, SCHWAB_APP_SECRET, SCHWAB_TOKEN_JSON
-  DAYS_BACK (default 60)
+  DAYS_BACK (default 5)
 
 Output tab: sw_txn_raw with RAW_HEADERS below
 """
@@ -307,9 +307,9 @@ def main() -> int:
         return 1
 
     try:
-        days_back = int((os.environ.get("DAYS_BACK") or "60").strip())
+        days_back = int((os.environ.get("DAYS_BACK") or "5").strip())
     except Exception:
-        days_back = 60
+        days_back = 5
     end_dt = datetime.now(timezone.utc)
     start_dt = end_dt - timedelta(days=days_back)
 


### PR DESCRIPTION
## Summary
- update the Schwab dump workflow defaults to keep only five days of history and document the new behavior
- run the scheduled workflow every day at 00:00 UTC instead of only Tuesday through Saturday
- align the Python script default to the five-day window so manual runs use the same lookback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccc91344dc8320abc3b7532b82c7ee