### PR TITLE
Treat Schwab PUT 204 responses as success

### DIFF
--- a/scripts/leocross_place_simple.py
+++ b/scripts/leocross_place_simple.py
@@ -158,7 +158,7 @@ def schwab_put_json(c, url, payload, tries=6, tag=""):
     for i in range(tries):
         try:
             r = c.session.put(url, json=payload, timeout=20)
-            if r.status_code in (200, 201, 202):
+            if r.status_code in (200, 201, 202, 204):
                 return r
             if r.status_code == 429:
                 time.sleep(_sleep_for_429(r, i)); continue


### PR DESCRIPTION
## Summary
- allow the Schwab PUT helper to treat HTTP 204 as a successful response

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cccb0349e08320ac419f1c8cfc787a