### PR TITLE
Configure LeoCross ladder env defaults

### DIFF
--- a/.github/workflows/leocross.yml
+++ b/.github/workflows/leocross.yml
@@ -58,6 +58,13 @@ jobs:
           GW_TOKEN:    ${{ secrets.GW_TOKEN }}
           GW_EMAIL:    ${{ secrets.GW_EMAIL }}
           GW_PASSWORD: ${{ secrets.GW_PASSWORD }}
+          REPLACE_MODE: "CANCEL_REPLACE"
+          CREDIT_FLOOR: "4.80"
+          CREDIT_PER5_START: "2.00"
+          CREDIT_STEP: "0.05"
+          RESET_TO_START: "1"
+          STEP_WAIT_CREDIT: "10"
+          MAX_LADDER_CYCLES: "3"
           PYTHONUNBUFFERED: "1"
         run: |
           python scripts/leocross_orchestrator.py


### PR DESCRIPTION
## Summary
- set explicit ladder control environment values for the LeoCross workflow step so the placer runs in cancel-replace mode with the expected credit parameters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cccb4999588320b9e102a58ba80787