### PR TITLE
Clear Sheets tab before writing Schwab data

### DIFF
--- a/scripts/schwab_dump_all_txns.py
+++ b/scripts/schwab_dump_all_txns.py
@@ -71,6 +71,10 @@ def ensure_tab_with_header(svc, sid: str, tab: str, headers: List[str]) -> None:
         ).execute()
 
 def overwrite_rows(svc, sid: str, tab: str, headers: List[str], rows: List[List[Any]]) -> None:
+    svc.spreadsheets().values().clear(
+        spreadsheetId=sid,
+        range=tab,
+    ).execute()
     svc.spreadsheets().values().update(
         spreadsheetId=sid,
         range=f"{tab}!A1",


### PR DESCRIPTION
## Summary
- clear the target Sheets tab prior to updating rows so stale data is removed

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68cccd9095c483209065c24dcab006cd