### PR TITLE
Filter Schwab summaries to exclude future expirations

### DIFF
--- a/scripts/schwab_summarize_txns.py
+++ b/scripts/schwab_summarize_txns.py
@@ -13,16 +13,25 @@ from googleapiclient.discovery import build as gbuild
 SUMMARY_TAB = "sw_txn_summary"
 SUMMARY_FORMULA = dedent(
     """\
-    =ARRAYFORMULA({
-      "exp_primary","net_amount_sum";
-      SORT(
-        QUERY(sw_txn_raw!A:Q,
+    =LET(
+      raw,
+        QUERY(
+          sw_txn_raw!A:Q,
           "select H, sum(N) where H is not null group by H label sum(N) ''",
           1
         ),
-        1, TRUE
-      )
-    })
+      cutoff,
+        TEXT(TODAY() - 1, "yyyy-mm-dd"),
+      filtered,
+        IF(
+          ROWS(raw),
+          IFERROR(FILTER(raw, INDEX(raw,,1) <= cutoff), {}),
+          {}
+        ),
+      sorted,
+        IF(ROWS(filtered), SORT(filtered, 1, TRUE), filtered),
+      VSTACK({"exp_primary","net_amount_sum"}, sorted)
+    )
     """
 ).strip()
 


### PR DESCRIPTION
## Summary
- add helpers to normalize sheet dates and compute yesterday’s ET cutoff
- filter trade summaries and performance stats so only expirations through yesterday are included
- update the Sheets summary formula to mirror the new cutoff logic

## Testing
- python -m compileall scripts/schwab_dump_all_txns.py scripts/schwab_summarize_txns.py

------
https://chatgpt.com/codex/tasks/task_e_68ccf96a85088320a43a57681ff35840