### PR TITLE
Adjust LeoCross ladder env defaults

### DIFF
--- a/.github/workflows/leocross.yml
+++ b/.github/workflows/leocross.yml
@@ -58,15 +58,16 @@ jobs:
           GW_TOKEN:    ${{ secrets.GW_TOKEN }}
           GW_EMAIL:    ${{ secrets.GW_EMAIL }}
           GW_PASSWORD: ${{ secrets.GW_PASSWORD }}
-          REPLACE_MODE: "CANCEL_REPLACE"
+          REPLACE_MODE: "REPLACE"
           CREDIT_FLOOR: "4.80"
           CREDIT_PER5_START: "2.00"
           CREDIT_STEP: "0.05"
           RESET_TO_START: "1"
-          STEP_WAIT_CREDIT: "10"
-          MAX_RUNTIME_SECS: "900"
+          STEP_WAIT_CREDIT: "1"
+          MAX_RUNTIME_SECS: "170"
           DISCRETE_CREDIT_LADDER: "6,5.70,5.50,5.40,5.30,5.25,5.20,5.15,5.10,5.05,5.00"
-          CYCLES_WITH_REFRESH: "3"
+          CYCLES_WITH_REFRESH: "1"
+          CANCEL_SETTLE_SECS: "0.5"
           MAX_LADDER_CYCLES: "3"
           PYTHONUNBUFFERED: "1"
         run: |


### PR DESCRIPTION
## Summary
- switch the GitHub Actions LeoCross workflow to use REPLACE ladder mode
- tighten the ladder runtime, cancel settle, and step wait configuration to the requested values

## Testing
- not run (workflow configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd0a0b945c8320919be7c9901516bd