### PR TITLE
Add timedelta import to leocross placer

### DIFF
--- a/scripts/leocross_place_simple.py
+++ b/scripts/leocross_place_simple.py
@@ -6,7 +6,7 @@
 # - Default mode MANUAL; SCHEDULED gate only if explicitly set
 
 import os, sys, json, time, re, math, random
-from datetime import datetime, date, timezone
+from datetime import datetime, date, timezone, timedelta
 from zoneinfo import ZoneInfo
 import requests
 from schwab.auth import client_from_token_file


### PR DESCRIPTION
## Summary
- add timedelta to the datetime imports in leocross_place_simple.py

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd0f3b4a4083209b2520fdee438e57