### PR TITLE
Add final cancel sweep for lingering Schwab orders

### DIFF
--- a/scripts/leocross_place_simple.py
+++ b/scripts/leocross_place_simple.py
@@ -800,6 +800,20 @@ def main():
         except Exception:
             pass
 
+    # Final sweep to guarantee no stray working/accepted orders for these legs
+    try:
+        ex, st, ovs = pick_active_and_overlaps(c, acct_hash, canon)
+        for oid in ([ex] if ex else []) + ovs:
+            url = f"https://api.schwabapi.com/trader/v1/accounts/{acct_hash}/orders/{oid}"
+            try:
+                schwab_delete(c, url, tag=f"CANCEL_SWEEP:{oid}")
+                wait_until_closed(oid, max_wait=1.5)
+                vprint(f"CANCEL_SWEEP OID={oid}")
+            except Exception:
+                pass
+    except Exception:
+        pass
+
     # ===== Log outcome
     used_price = steps[-1].split("@",1)[0] if steps else ""
     oid_for_log = active_oid or ""


### PR DESCRIPTION
## Summary
- add a defensive cleanup pass that cancels any Schwab orders still shown as active for the trade legs

## Testing
- python -m compileall scripts/leocross_place_simple.py

------
https://chatgpt.com/codex/tasks/task_e_68cd149855788320b2c88727b1ef36a3