### PR TITLE
Fix indentation causing refresh call error

### DIFF
--- a/scripts/leocross_place_simple.py
+++ b/scripts/leocross_place_simple.py
@@ -787,7 +787,6 @@ def main():
         cycles += 1
         # For your spec: after each pass, re-fetch Leo and rebuild legs
         if is_credit and DISCRETE_CREDIT_LADDER and filled_total < qty and cycles < _max_cycles:
-             refresh_from_leo()
             refresh_from_leo()
 
     # final cleanup if still working


### PR DESCRIPTION
## Summary
- remove stray mis-indented refresh call inside the credit-ladder loop

## Testing
- python -m py_compile scripts/leocross_place_simple.py

------
https://chatgpt.com/codex/tasks/task_e_68cd15f2e4248320b3dacf177431df4c