### PR TITLE
Add explicit anchor timing envs for LeoCross

### DIFF
--- a/.github/workflows/leocross.yml
+++ b/.github/workflows/leocross.yml
@@ -63,7 +63,10 @@ jobs:
           CREDIT_STEP: "0.05"
           RESET_TO_START: "1"
           CANCEL_SETTLE_SECS: "0.5"
+          # New/updated knobs for the fast two-pass plan
           MAX_LADDER_CYCLES: "2"
+          ANCHOR_WAIT_SECS:  "10"
+          DEBIT_ANCHOR_MODE: "BID"
           PYTHONUNBUFFERED: "1"
         run: |
           python scripts/leocross_orchestrator.py


### PR DESCRIPTION
## Summary
- add explicit anchor wait and debit anchor mode environment settings to the LeoCross workflow
- document the fast two-pass plan in the workflow configuration comments

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68cdd88b22c08320ac2f500b01908b14