### PR TITLE
Allow skipping Schwab summary generation

### DIFF
--- a/.github/workflows/schwab_transactions.yml
+++ b/.github/workflows/schwab_transactions.yml
@@ -43,6 +43,7 @@ jobs:
           SCHWAB_APP_SECRET: ${{ secrets.SCHWAB_APP_SECRET }}
           SCHWAB_TOKEN_JSON: ${{ secrets.SCHWAB_TOKEN_JSON }}
           DAYS_BACK: ${{ github.event.inputs.days_back != '' && github.event.inputs.days_back || '5' }}
+          SCHWAB_SKIP_SUMMARY: "1"
         run: |
           python scripts/schwab_dump_all_txns.py
       # - name: Summarize sw_txn_raw → sw_txn_accum + sw_summary_by_expiry


### PR DESCRIPTION
## Summary
- add an environment flag to the Schwab dump script so summary generation can be skipped
- update the scheduled workflow to set the new flag and avoid running summaries

## Testing
- python -m compileall scripts/schwab_dump_all_txns.py

------
https://chatgpt.com/codex/tasks/task_e_68ce415d4520832088834abe38c54bb2