### PR TITLE
Add helper to guard hard cutoff parsing

### DIFF
--- a/scripts/leocross_place_simple.py
+++ b/scripts/leocross_place_simple.py
@@ -121,8 +121,16 @@ def parse_hhmm_et(s: str) -> datetime:
     now = datetime.now(ET)
     return now.replace(hour=hh, minute=mm, second=0, microsecond=0)
 
+def _cutoff_reached() -> bool:
+    try:
+        hh, mm = [int(x) for x in HARD_CUTOFF_HHMM.split(":")]
+        now = datetime.now(ET)
+        return (now.hour > hh) or (now.hour == hh and now.minute >= mm)
+    except Exception:
+        return False
+
 def cutoff_reached() -> bool:
-    return datetime.now(ET) >= parse_hhmm_et(HARD_CUTOFF_HHMM)
+    return _cutoff_reached()
 
 # ===== Sheets =====
 def ensure_header_and_get_sheetid(svc, spreadsheet_id: str, tab: str, header: list):


### PR DESCRIPTION
## Summary
- add a `_cutoff_reached` helper to evaluate the HARD_CUTOFF_HHMM setting defensively
- route `cutoff_reached` through the helper for a consistent, safe cutoff check

## Testing
- python -m compileall scripts/leocross_place_simple.py

------
https://chatgpt.com/codex/tasks/task_e_68cec30d5f588320ae7baa127b198091