### PR TITLE
Update Schwab workflow to skip summary

### DIFF
--- a/.github/workflows/schwab_transactions.yml
+++ b/.github/workflows/schwab_transactions.yml
@@ -43,13 +43,6 @@ jobs:
           SCHWAB_APP_SECRET: ${{ secrets.SCHWAB_APP_SECRET }}
           SCHWAB_TOKEN_JSON: ${{ secrets.SCHWAB_TOKEN_JSON }}
           DAYS_BACK: ${{ github.event.inputs.days_back != '' && github.event.inputs.days_back || '5' }}
-          SCHWAB_SKIP_SUMMARY: "1"
+          SCHWAB_SKIP_SUMMARY: "0"
         run: |
           python scripts/schwab_dump_all_txns.py
-      - name: Summarize sw_txn_raw → sw_txn_accum + sw_summary_by_expiry
-        env:
-          GSHEET_ID: ${{ secrets.GSHEET_ID }}
-          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
-          ACC_RESET: ${{ github.event.inputs.acc_reset != '' && github.event.inputs.acc_reset || '0' }}
-        run: |
-          python scripts/schwab_summarize_txns.py


### PR DESCRIPTION
## Summary
- set `SCHWAB_SKIP_SUMMARY` to 0 in the dump step so the Python workflow performs the summary
- remove the now-unnecessary separate summary step from the Schwab transactions workflow

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3d1d286708320894e9f3bd55d5f91