### PR TITLE
Add 3-way expiry summary step to Schwab dump workflow

### DIFF
--- a/.github/workflows/schwab_dump.yml
+++ b/.github/workflows/schwab_dump.yml
@@ -43,3 +43,10 @@ jobs:
           DAYS_BACK: ${{ github.event.inputs.days_back != '' && github.event.inputs.days_back || '4' }}
         run: |
           python scripts/sw_dump_raw.py
+      - name: 3-way expiry summary (Leo vs Standard vs Adjusted)
+        env:
+          GSHEET_ID: ${{ secrets.GSHEET_ID }}
+          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
+          UNIT_RISK: "4500"
+        run: |
+          python scripts/sw_3way_summary.py


### PR DESCRIPTION
## Summary
- add a job step to run the three-way expiry summary script after the Schwab dump

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4bd6d52bc8320b0ac4d32bb58fa4a