### PR TITLE
Update workflow paths for relocated scripts

### DIFF
--- a/.github/workflows/leocross.yml
+++ b/.github/workflows/leocross.yml
@@ -89,4 +89,4 @@ jobs:
           VERBOSE: "1"
           PYTHONUNBUFFERED: "1"
         run: |
-          python scripts/leocross_orchestrator.py
+          python scripts/trade/leocross_orchestrator.py

--- a/.github/workflows/schwab_dump.yml
+++ b/.github/workflows/schwab_dump.yml
@@ -42,11 +42,11 @@ jobs:
           BACKFILL_YTD: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.backfill_ytd == 'true' && '1' || '0') || '0' }}
           DAYS_BACK: ${{ github.event.inputs.days_back != '' && github.event.inputs.days_back || '4' }}
         run: |
-          python scripts/sw_dump_raw.py
+          python scripts/data/sw_dump_raw.py
       - name: 3-way expiry summary (Leo vs Standard vs Adjusted)
         env:
           GSHEET_ID: ${{ secrets.GSHEET_ID }}
           GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
           UNIT_RISK: "4500"
         run: |
-          python scripts/sw_3way_summary.py
+          python scripts/data/sw_3way_summary.py

--- a/.github/workflows/schwab_transactions.yml
+++ b/.github/workflows/schwab_transactions.yml
@@ -45,4 +45,4 @@ jobs:
           DAYS_BACK: ${{ github.event.inputs.days_back != '' && github.event.inputs.days_back || '5' }}
           SCHWAB_SKIP_SUMMARY: "0"
         run: |
-          python scripts/schwab_dump_all_txns.py
+          python scripts/data/schwab_dump_all_txns.py


### PR DESCRIPTION
## Summary
- update GitHub workflow scripts to point to their new locations under scripts/data and scripts/trade

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4c962a8e88320b0d58aa4052db2b2