### PR TITLE
Add Leo ingestion step to Schwab dump workflow

### DIFF
--- a/.github/workflows/schwab_dump.yml
+++ b/.github/workflows/schwab_dump.yml
@@ -43,6 +43,19 @@ jobs:
           DAYS_BACK: ${{ github.event.inputs.days_back != '' && github.event.inputs.days_back || '4' }}
         run: |
           python scripts/data/sw_dump_raw.py
+      - name: Ingest Leo → sw_leo_orders (NBBO mid, 5-wide)
+        if: always()
+        env:
+          GSHEET_ID: ${{ secrets.GSHEET_ID }}
+          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
+          SCHWAB_APP_KEY: ${{ secrets.SCHWAB_APP_KEY }}
+          SCHWAB_APP_SECRET: ${{ secrets.SCHWAB_APP_SECRET }}
+          SCHWAB_TOKEN_JSON: ${{ secrets.SCHWAB_TOKEN_JSON }}
+          GW_EMAIL: ${{ secrets.GW_EMAIL }}
+          GW_PASSWORD: ${{ secrets.GW_PASSWORD }}
+          # or GW_TOKEN instead of GW_EMAIL/GW_PASSWORD
+        run: |
+          python scripts/data/gw_leo_to_sheet.py
       - name: 3-way expiry summary (Leo vs Standard vs Adjusted)
         env:
           GSHEET_ID: ${{ secrets.GSHEET_ID }}


### PR DESCRIPTION
## Summary
- add a Leo ingestion step that runs after the Schwab dump in the schwab workflow
- configure the job to always run with required secrets and environment variables

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d4c9eda0448320b1c2b37207175f12