### PR TITLE
Add GammaWizard settlement step to Schwab workflow

### DIFF
--- a/.github/workflows/schwab_dump.yml
+++ b/.github/workflows/schwab_dump.yml
@@ -56,7 +56,33 @@ jobs:
           # or GW_TOKEN instead of GW_EMAIL/GW_PASSWORD
         run: |
           python scripts/data/gw_leo_to_sheet.py
-      - name: 3-way expiry summary (Std+Adj from raw; Leo/Std P&L waits for settle)
+      - name: 3-way expiry summary (Step-1: Std+Adj from raw; Leo/Std P&L waits for settle)
+        env:
+          GSHEET_ID: ${{ secrets.GSHEET_ID }}
+          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
+          UNIT_RISK: "4500"
+          ORIG_ET_START: "16:00"
+          ORIG_ET_END: "16:20"
+          ORIG_DAYS_BEFORE: "1"
+          ALLOCATE_MULTI_EXP: "1"
+        run: |
+          python scripts/data/sw_3way_summary.py
+      - name: SPX settlements from GammaWizard (fallback Schwab)
+        env:
+          GSHEET_ID: ${{ secrets.GSHEET_ID }}
+          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
+          GW_BASE: ${{ secrets.GW_BASE }}
+          GW_TOKEN: ${{ secrets.GW_TOKEN }}
+          GW_EMAIL: ${{ secrets.GW_EMAIL }}
+          GW_PASSWORD: ${{ secrets.GW_PASSWORD }}
+          GW_SETTLE_ENDPOINT: ${{ secrets.GW_SETTLE_ENDPOINT }}
+          SCHWAB_APP_KEY: ${{ secrets.SCHWAB_APP_KEY }}
+          SCHWAB_APP_SECRET: ${{ secrets.SCHWAB_APP_SECRET }}
+          SCHWAB_TOKEN_JSON: ${{ secrets.SCHWAB_TOKEN_JSON }}
+          SETTLE_BACKFILL_DAYS: "180"
+        run: |
+          python scripts/data/gw_settlements_to_sheet.py
+      - name: Rebuild 3-way summary with settle P&L on
         env:
           GSHEET_ID: ${{ secrets.GSHEET_ID }}
           GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}


### PR DESCRIPTION
## Summary
- run the SPX settlements sync after the initial 3-way summary to pull data from GammaWizard (and Schwab as fallback)
- rerun the 3-way summary so that settlement P&L is included once settlements are synced

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d4d59ca0848320a6fc8132822198e8