### PR TITLE
Update leocross placer path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A. Orchestrator (guard + runner) — scripts/leocross_orchestrator.py
 	•	Backoff/retry on Schwab HTTP calls.
 	•	Per‑run lock (based on GITHUB_RUN_ID) + duplicate‑main sentinel so it can’t run twice inside a single job even if the file is ever pasted twice by mistake.
 
-B. Placer (ladder) — scripts/leocross_place_simple.py
+B. Placer (ladder) — scripts/trade/leocross_place_simple.py
 	•	Takes the four legs from LeoCross.
 	•	Quantity: uses QTY_OVERRIDE if present; otherwise a hard‑coded constant at the top of the file (set to 4 as you asked). No OBP sizing. No balance checks.
 	•	Cancel/replace ladder (one cycle):
@@ -91,7 +91,7 @@ Secrets (GitHub → Settings → Secrets and variables → Actions):
 	•	GOOGLE_SERVICE_ACCOUNT_JSON (service account JSON with edit rights on that sheet)
 	•	GammaWizard: GW_TOKEN (optional), GW_EMAIL, GW_PASSWORD (fallback auth)
 
-Placer constants (top of leocross_place_simple.py):
+Placer constants (top of scripts/trade/leocross_place_simple.py):
 	•	QTY_FIXED = 4 (your hard‑coded quantity when QTY_OVERRIDE not set)
 	•	Ladder tuning:
 	•	STEP_WAIT = 30 (seconds between checks)

--- a/scripts/trade/leocross_orchestrator.py
+++ b/scripts/trade/leocross_orchestrator.py
@@ -435,7 +435,7 @@ def main():
     env["PLACER_MODE"]  = "MANUAL"
     env["VERBOSE"]      = env.get("VERBOSE","1")
     print(f"ORCH CALL → PLACER QTY_OVERRIDE={env['QTY_OVERRIDE']} MODE={env['PLACER_MODE']}")
-    rc = os.spawnve(os.P_WAIT, sys.executable, [sys.executable, "scripts/leocross_place_simple.py"], env)
+    rc = os.spawnve(os.P_WAIT, sys.executable, [sys.executable, "scripts/trade/leocross_place_simple.py"], env)
     return rc
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- point README references to the placer script's scripts/trade location
- update the orchestrator to spawn the placer from scripts/trade/leocross_place_simple.py

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5b03e6cbc8320a3832645567ac77b