### PR TITLE
Gate txn totals to first ledger leg row

### DIFF
--- a/scripts/data/schwab_dump_all_txns.py
+++ b/scripts/data/schwab_dump_all_txns.py
@@ -636,7 +636,7 @@ def rows_from_ledger_txn(txn: Dict[str, Any]) -> List[List[Any]]:
 
     rows: List[List[Any]] = []
     seen_leg = set()  # prevent duplicates within the same ledger activity
-    did_attach_totals = False  # ensure net/fees only emitted once per ledger txn
+    first_leg = True  # gate txn-level fields to the first leg row only
 
     for it in (txn.get("transferItems") or []):
         inst = it.get("instrument") or {}
@@ -670,24 +670,17 @@ def rows_from_ledger_txn(txn: Dict[str, Any]) -> List[List[Any]]:
             continue
         seen_leg.add(leg_key)
 
-        # attach ledger-level totals/net ONCE (first option leg)
-        if not did_attach_totals:
-            net_for_row = txn.get("netAmount") if txn.get("netAmount") is not None else ""
-            comm_for_row = comm_total or ""
-            fees_for_row = fees_total or ""
-            did_attach_totals = True
-        else:
-            net_for_row = ""
-            comm_for_row = ""
-            fees_for_row = ""
-
         rows.append([
             ts, txn_id_for_sheet, ttype, subtype, desc,
             symbol, underlying, (exp_primary or ""), (strike if strike is not None else ""), pc,
             (qty if qty is not None else ""), (price if price is not None else ""), (amt if amt is not None else ""),
-            net_for_row, comm_for_row, fees_for_row,
+            (txn.get("netAmount") if (first_leg and txn.get("netAmount") is not None) else ""),
+            (comm_total if (first_leg and comm_total) else ""),
+            (fees_total if (first_leg and fees_total) else ""),
             "schwab_ledger", ledger_id
         ])
+
+        first_leg = False
 
     return rows
 


### PR DESCRIPTION
## Summary
- ensure Schwab ledger transaction-level totals only populate the first option leg row to avoid duplication

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6020800388320bb8a672d2ee25c52