### PR TITLE
Set Schwab skip summary flag

### DIFF
--- a/.github/workflows/schwab_raw_data.yml
+++ b/.github/workflows/schwab_raw_data.yml
@@ -59,6 +59,7 @@ jobs:
           SCHWAB_TOKEN_JSON: ${{ secrets.SCHWAB_TOKEN_JSON }}
           BACKFILL_YTD: ${{ steps.dump_params.outputs.BACKFILL_YTD }}
           DAYS_BACK:    ${{ steps.dump_params.outputs.DAYS_BACK }}
+          SCHWAB_SKIP_SUMMARY: "1"
         run: |
           python scripts/data/sw_dump_raw.py
 


### PR DESCRIPTION
## Summary
- set `SCHWAB_SKIP_SUMMARY=1` in the Schwab raw data workflow so only the sw_txn_raw tab is updated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d60221fda08320bf9e08c579cd390c