### PR TITLE
Ensure orig-only Schwab summary uses hot path

### DIFF
--- a/.github/workflows/schwab_raw_data.yml
+++ b/.github/workflows/schwab_raw_data.yml
@@ -97,6 +97,7 @@ jobs:
           GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
           ORIG_ET_START: "16:00"
           ORIG_ET_END:   "16:20"
-          ORIG_DAYS_BEFORE: "1"   # business days
+          ORIG_DAYS_BEFORE: "1"
+          ORIG_ONLY: "1"   # ensures the hot path runs
         run: |
           python scripts/data/sw_3way_summary.py


### PR DESCRIPTION
## Summary
- add ORIG_ONLY flag to the Schwab orig-order build step so the workflow always takes the orig-only path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d634db79448320b1cc4e147b899e51