### PR TITLE
Fix run_gw_inspect workflow configuration

### DIFF
--- a/.github/workflows/run_gw_inspect.yml
+++ b/.github/workflows/run_gw_inspect.yml
@@ -1,3 +1,8 @@
+name: Run GammaWizard Inspect
+
+on:
+  workflow_dispatch:
+
 jobs:
   run-inspect:
     runs-on: ubuntu-latest
@@ -6,8 +11,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: pip install -r requirements.txt
-      - run: python gw_inspect.py
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run inspect script
+        run: python scripts/data/gw_inspect.py
         env:
           GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
           GSHEET_ID: ${{ secrets.GSHEET_ID }}


### PR DESCRIPTION
## Summary
- add workflow name and manual trigger configuration for run_gw_inspect
- ensure the workflow installs dependencies and runs the inspect script from the correct location

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcaf167fdc8320aaaee44283f7781b