### PR TITLE
Add artifact upload for GW inspect workflow

### DIFF
--- a/.github/workflows/run_gw_inspect.yml
+++ b/.github/workflows/run_gw_inspect.yml
@@ -20,3 +20,10 @@ jobs:
         env:
           GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
           GSHEET_ID: ${{ secrets.GSHEET_ID }}
+      - name: Upload GW dumps
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gw-dump
+          path: gw_dump/*.json
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- add an artifact upload step to persist gw_dump JSON files after the inspect script runs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcbb8ce0848320b840d302f9c25a63